### PR TITLE
Simplify code.

### DIFF
--- a/annotate_test.go
+++ b/annotate_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"path/filepath"
 	"sort"
@@ -251,7 +250,7 @@ func TestAnnotate_Files(t *testing.T) {
 		anns := annsByFile[name]
 		sort.Sort(anns)
 
-		got, err := Annotate(input, anns, func(w io.Writer, b []byte) { template.HTMLEscape(w, b) })
+		got, err := Annotate(input, anns, template.HTMLEscape)
 		if err != nil {
 			t.Errorf("%s: Annotate: %s", name, err)
 			continue


### PR DESCRIPTION
Don't create an unneeded extra closure, use `template.HTMLEscape` func directly.

Inspired by Andrew Gerrand's [excellent recent talk](https://twitter.com/enneff/status/634693712233295872).